### PR TITLE
Add pagerduty webhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+jdk:
+    - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: java
+
 jdk:
-    - oraclejdk8
+  - oraclejdk8
+
+before_script:
+  - pip install --user codecov
+
+after_success:
+  - codecov

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # zmon-notification-service
+
+Running locally enables the dry run mode by default. This disables most production services, namely:
+
+- The TokenService supports a single shared key "DRY-RUN" valid for a long time
+- PagerDuty Web Hook accepts calls but only logs what it would do;

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # zmon-notification-service
 
+[![Build Status](https://travis-ci.org/zalando-zmon/zmon-notification-service.svg?branch=master)](https://travis-ci.org/zalando-zmon/zmon-notification-service)
+[![codecov.io](https://codecov.io/github/zalando-zmon/zmon-notification-service/coverage.svg?branch=master)](https://codecov.io/github/zalando-zmon/zmon-notification-service?branch=master)
+
 Running locally enables the dry run mode by default. This disables most production services, namely:
 
 - The TokenService supports a single shared key "DRY-RUN" valid for a long time

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
 			<artifactId>tokens</artifactId>
 			<version>0.9.9</version>
 		</dependency>
+		<dependency>
+			<groupId>net.jodah</groupId>
+			<artifactId>failsafe</artifactId>
+			<version>1.0.4</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/zalando/zmon/notifications/ZMonEventType.java
+++ b/src/main/java/org/zalando/zmon/notifications/ZMonEventType.java
@@ -39,12 +39,15 @@ public enum ZMonEventType implements EventType {
     CALL_ANSWERED(0x34202, "alertId", "entityIds", "phone"),
     CALL_ALERT_ACK_RECEIVED(0x3420A, "alertId", "phone", "incidentId"),
     CALL_ENTITY_ACK_RECEIVED(0x3420B, "alertId", "phone", "entityIds", "incidentId"),
-    CALL_ALERT_RESOLVED(0x34210, "alertId", "incidentId");
+    CALL_ALERT_RESOLVED(0x34210, "alertId", "incidentId"),
+
+    // Abstract paging provider events
+    PAGE_ACKNOWLEDGED(0x34301, "alertId", "userName");
 
     private final int id;
     private final List<String> fieldNames;
 
-    private ZMonEventType(final int id, final String... fieldNames) {
+    ZMonEventType(final int id, final String... fieldNames) {
         this.id = id;
         this.fieldNames = Lists.newArrayList(fieldNames);
     }

--- a/src/main/java/org/zalando/zmon/notifications/config/NotificationServiceConfig.java
+++ b/src/main/java/org/zalando/zmon/notifications/config/NotificationServiceConfig.java
@@ -13,6 +13,8 @@ import java.util.Map;
 @Configuration
 @ConfigurationProperties(prefix = "notifications")
 public class NotificationServiceConfig {
+    public static final String PAGERDUTY_API_DEFAULT_URL = "https://api.pagerduty.com";
+
     private String oauthInfoServiceUrl;
 
     private String googleUrl;
@@ -49,6 +51,12 @@ public class NotificationServiceConfig {
     private String oauth2AccessTokenUrl = null;
     private List<String> oauth2Scopes = Arrays.asList("uid");
     private String oauth2StaticToken = "";
+
+    private String pagerDutyApiUrl = PAGERDUTY_API_DEFAULT_URL;
+    private String pagerDutyApiKey = "";
+    private int pagerDutyConnectTimeout = 5000;
+    private int pagerDutyRequestConnectionTimeout = 5000;
+    private int pagerDutySocketTimeout = 5000;
 
     private boolean dryRun = true;
 
@@ -269,5 +277,45 @@ public class NotificationServiceConfig {
 
     public void setOauth2StaticToken(String oauth2StaticToken) {
         this.oauth2StaticToken = oauth2StaticToken;
+    }
+
+    public String getPagerDutyApiUrl() {
+        return pagerDutyApiUrl;
+    }
+
+    public void setPagerDutyApiUrl(String pagerDutyApiUrl) {
+        this.pagerDutyApiUrl = pagerDutyApiUrl;
+    }
+
+    public String getPagerDutyApiKey() {
+        return pagerDutyApiKey;
+    }
+
+    public void setPagerDutyApiKey(String pagerDutyApiKey) {
+        this.pagerDutyApiKey = pagerDutyApiKey;
+    }
+
+    public int getPagerDutyConnectTimeout() {
+        return pagerDutyConnectTimeout;
+    }
+
+    public void setPagerDutyConnectTimeout(int pagerDutyConnectTimeout) {
+        this.pagerDutyConnectTimeout = pagerDutyConnectTimeout;
+    }
+
+    public int getPagerDutyRequestConnectionTimeout() {
+        return pagerDutyRequestConnectionTimeout;
+    }
+
+    public void setPagerDutyRequestConnectionTimeout(int pagerDutyRequestConnectionTimeout) {
+        this.pagerDutyRequestConnectionTimeout = pagerDutyRequestConnectionTimeout;
+    }
+
+    public int getPagerDutySocketTimeout() {
+        return pagerDutySocketTimeout;
+    }
+
+    public void setPagerDutySocketTimeout(int pagerDutySocketTimeout) {
+        this.pagerDutySocketTimeout = pagerDutySocketTimeout;
     }
 }

--- a/src/main/java/org/zalando/zmon/notifications/oauth/ChainedTokenInfo.java
+++ b/src/main/java/org/zalando/zmon/notifications/oauth/ChainedTokenInfo.java
@@ -14,9 +14,9 @@ public class ChainedTokenInfo implements TokenInfoService {
 
     TokenInfoService[] services;
 
-    public ChainedTokenInfo(TokenInfoService... service) {
-            services = service;
-            for(TokenInfoService s : services) {
+    public ChainedTokenInfo(TokenInfoService... services) {
+            this.services = services;
+            for(TokenInfoService s : this.services) {
                 log.info("TokenInfo entry: {}", s.getClass());
             }
     }

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/Config.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/Config.java
@@ -1,0 +1,59 @@
+package org.zalando.zmon.notifications.pagerduty;
+
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.client.RestTemplate;
+import org.zalando.zmon.notifications.config.NotificationServiceConfig;
+import org.zalando.zmon.notifications.pagerduty.client.DefaultClient;
+import org.zalando.zmon.notifications.pagerduty.client.PagerDutyClient;
+import org.zalando.zmon.notifications.pagerduty.client.PagerDutyClientInterceptor;
+import org.zalando.zmon.notifications.pagerduty.webhook.AlertStore;
+import org.zalando.zmon.notifications.pagerduty.webhook.RedisAlertStore;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@Configuration
+public class Config {
+    @Bean()
+    public RestOperations pagerDutyRestOperations(final NotificationServiceConfig config) {
+        final RestTemplate restTemplate = new RestTemplate(getClientHttpRequestFactory(config));
+        restTemplate.getInterceptors().add(new PagerDutyClientInterceptor(config.getPagerDutyApiKey()));
+        return restTemplate;
+    }
+
+    private ClientHttpRequestFactory getClientHttpRequestFactory(final NotificationServiceConfig config) {
+        final RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(config.getPagerDutyConnectTimeout())
+                .setConnectionRequestTimeout(config.getPagerDutyRequestConnectionTimeout())
+                .setSocketTimeout(config.getPagerDutySocketTimeout())
+                .build();
+        final CloseableHttpClient client = HttpClientBuilder
+                .create()
+                .setDefaultRequestConfig(requestConfig)
+                .build();
+        return new HttpComponentsClientHttpRequestFactory(client);
+    }
+
+    @Bean
+    public PagerDutyClient pagerDutyClient(final NotificationServiceConfig config, final RestOperations pagerDutyRestOperations) {
+        return new DefaultClient(pagerDutyRestOperations, config.getPagerDutyApiUrl());
+    }
+
+    @Bean
+    public AlertStore redisAlertStore(final NotificationServiceConfig config) throws URISyntaxException {
+        final JedisPoolConfig poolConfig = new JedisPoolConfig();
+        poolConfig.setTestOnBorrow(true);
+        final JedisPool jedisPool = new JedisPool(poolConfig, new URI(config.getRedisUri()));
+        return new RedisAlertStore(jedisPool);
+    }
+
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/client/AbstractResilientClient.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/client/AbstractResilientClient.java
@@ -1,0 +1,44 @@
+package org.zalando.zmon.notifications.pagerduty.client;
+
+import net.jodah.failsafe.CircuitBreaker;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.client.HttpServerErrorException;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+class AbstractResilientClient {
+    private final Logger log = LoggerFactory.getLogger(AbstractResilientClient.class);
+
+    private RetryPolicy retryPolicy;
+    private CircuitBreaker circuitBreaker;
+
+    AbstractResilientClient() {
+        this.retryPolicy = new RetryPolicy()
+                .retryOn(this::isTransientFailure)
+                .withBackoff(1, 3, TimeUnit.SECONDS)
+                .withJitter(0.1)
+                .withMaxRetries(3);
+        this.circuitBreaker = new CircuitBreaker()
+                .withFailureThreshold(3, 10)
+                .withSuccessThreshold(3)
+                .withDelay(1, TimeUnit.MINUTES)
+                .onOpen(() -> log.info("The PagerDuty circuit breaker was opened"));
+    }
+
+    private boolean isTransientFailure(Throwable failure) {
+        return failure instanceof IOException || failure instanceof HttpServerErrorException;
+    }
+
+    <T> T doResilientCall(final Callable<T> callable) {
+        return Failsafe.with(circuitBreaker)
+                .with(retryPolicy)
+                .onFailedAttempt(failure -> log.error("PagerDuty API call failed", failure))
+                .onRetry((c, f, ctx) -> log.warn("Failure #{}. Retrying.", ctx.getExecutions()))
+                .get(callable);
+    }
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/client/Alert.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/client/Alert.java
@@ -1,0 +1,23 @@
+package org.zalando.zmon.notifications.pagerduty.client;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Alert {
+    @JsonProperty("alert_key")
+    private String alertKey;
+
+    public String getAlertKey() {
+        return alertKey;
+    }
+
+    public void setAlertKey(String alertKey) {
+        this.alertKey = alertKey;
+    }
+
+    @Override
+    public String toString() {
+        return getAlertKey();
+    }
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/client/AlertsResponse.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/client/AlertsResponse.java
@@ -1,0 +1,17 @@
+package org.zalando.zmon.notifications.pagerduty.client;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+class AlertsResponse {
+    private List<Alert> alerts = ImmutableList.of();
+
+    List<Alert> getAlerts() {
+        return alerts;
+    }
+
+    public void setAlerts(List<Alert> alerts) {
+        this.alerts = alerts;
+    }
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/client/DefaultClient.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/client/DefaultClient.java
@@ -1,0 +1,38 @@
+package org.zalando.zmon.notifications.pagerduty.client;
+
+import com.google.common.base.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.client.RestOperations;
+
+import java.util.List;
+
+import static org.zalando.zmon.notifications.config.NotificationServiceConfig.PAGERDUTY_API_DEFAULT_URL;
+
+public class DefaultClient extends AbstractResilientClient implements PagerDutyClient {
+    private final Logger log = LoggerFactory.getLogger(DefaultClient.class);
+
+    private final String baseUrl;
+    private final RestOperations restOperations;
+
+    public DefaultClient(final RestOperations restOperations) {
+        this(restOperations, PAGERDUTY_API_DEFAULT_URL);
+    }
+
+    public DefaultClient(final RestOperations restOperations, String baseUrl) {
+        this.baseUrl = Strings.isNullOrEmpty(baseUrl) ? PAGERDUTY_API_DEFAULT_URL : baseUrl;
+        this.restOperations = restOperations;
+    }
+
+    @Override
+    public List<Alert> getAlerts(final String incidentId) {
+        final AlertsResponse response = doResilientCall(() -> doGetAlerts(incidentId));
+        return response.getAlerts();
+    }
+
+    private AlertsResponse doGetAlerts(final String incidentId) {
+        final String url = String.format("%s/incidents/%s/alerts", baseUrl, incidentId);
+        log.info("Loading PagerDuty alerts {}", url);
+        return restOperations.getForObject(url, AlertsResponse.class);
+    }
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/client/PagerDutyClient.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/client/PagerDutyClient.java
@@ -1,0 +1,7 @@
+package org.zalando.zmon.notifications.pagerduty.client;
+
+import java.util.List;
+
+public interface PagerDutyClient {
+    List<Alert> getAlerts(String incidentId);
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/client/PagerDutyClientInterceptor.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/client/PagerDutyClientInterceptor.java
@@ -1,0 +1,23 @@
+package org.zalando.zmon.notifications.pagerduty.client;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.IOException;
+
+public class PagerDutyClientInterceptor implements ClientHttpRequestInterceptor {
+    private final String authorizationToken;
+
+    public PagerDutyClientInterceptor(String apiKey) {
+        this.authorizationToken = String.format("Token token=%s", apiKey);
+    }
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+        request.getHeaders().set(HttpHeaders.AUTHORIZATION, authorizationToken);
+        return execution.execute(request, body);
+    }
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/AlertStore.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/AlertStore.java
@@ -1,0 +1,5 @@
+package org.zalando.zmon.notifications.pagerduty.webhook;
+
+public interface AlertStore {
+    void ackAlert(int alertId, String userName);
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/IntegrationHelper.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/IntegrationHelper.java
@@ -1,0 +1,17 @@
+package org.zalando.zmon.notifications.pagerduty.webhook;
+
+import com.google.common.base.Strings;
+
+public final class IntegrationHelper {
+    private IntegrationHelper() {}
+
+    public static int alertIdFromAlertKey(final String alertKey) {
+        if(Strings.isNullOrEmpty(alertKey)) {
+            throw new IllegalArgumentException("alertKey must be a valid, non-empty, string");
+        }
+        if(!alertKey.startsWith("ZMON-")) {
+            throw new IllegalArgumentException("alertKey must have the prefix `ZMON-`");
+        }
+        return Integer.parseInt(alertKey.replace("ZMON-", ""));
+    }
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/PagerDutyWebHookController.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/PagerDutyWebHookController.java
@@ -1,0 +1,104 @@
+package org.zalando.zmon.notifications.pagerduty.webhook;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.zalando.zmon.notifications.HttpEventLogger;
+import org.zalando.zmon.notifications.config.NotificationServiceConfig;
+import org.zalando.zmon.notifications.oauth.TokenInfoService;
+import org.zalando.zmon.notifications.pagerduty.client.Alert;
+import org.zalando.zmon.notifications.pagerduty.client.PagerDutyClient;
+import org.zalando.zmon.notifications.pagerduty.webhook.domain.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.zalando.zmon.notifications.ZMonEventType.PAGE_ACKNOWLEDGED;
+import static org.zalando.zmon.notifications.pagerduty.webhook.IntegrationHelper.alertIdFromAlertKey;
+
+@RestController
+@RequestMapping(path = "/api/v1/pagerduty")
+public class PagerDutyWebHookController {
+    private final Logger log = LoggerFactory.getLogger(PagerDutyWebHookController.class);
+
+    private final NotificationServiceConfig config;
+    private final TokenInfoService tokenInfoService;
+    private final HttpEventLogger eventLog;
+    private final PagerDutyClient client;
+    private final AlertStore alertStore;
+
+    @Autowired
+    public PagerDutyWebHookController(final PagerDutyClient client, final TokenInfoService tokenInfoService,
+                                      final NotificationServiceConfig notificationServiceConfig, final HttpEventLogger eventLog,
+                                      final AlertStore alertStore) {
+        this.config = notificationServiceConfig;
+        this.tokenInfoService = tokenInfoService;
+        this.eventLog = eventLog;
+        this.client = client;
+        this.alertStore = alertStore;
+        log.info("PagerDuty mode: dryRun={}", notificationServiceConfig.isDryRun());
+    }
+
+    @RequestMapping(path="/webhook", method = RequestMethod.POST, produces = "application/json")
+    public ResponseEntity<Void> ackNotification(@RequestParam(required = false) String psk, @RequestBody Callback callback) {
+        log.debug("Received PagerDuty Web Hook call");
+        Optional<String> uid = tokenInfoService.lookupUid(psk);
+        if (!uid.isPresent()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        for (final Message message: callback.getMessages()) {
+            if(!handleCallbackMessage(message)) {
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+            }
+        }
+
+        return ResponseEntity.ok().build();
+    }
+
+    private boolean handleCallbackMessage(final Message message) {
+        final MessageType messageType = message.getType();
+        switch(messageType) {
+            case ACKNOWLEDGE: {
+                return handleAcknowledge(message.getData());
+            }
+            default:
+                log.info("No handler for PagerDuty message type {}", messageType);
+        }
+        return true;
+    }
+
+    private boolean handleAcknowledge(final Data data) {
+        final Incident incident = data.getIncident();
+        final String incidentId = incident.getId();
+        final List<Acknowledger> acknowledgers = incident.getAcknowledgers();
+
+        if(acknowledgers.isEmpty()) {
+            log.error("Acknowledge without any acknowledgers");
+            return false;
+        }
+        final String userName = acknowledgers.get(0).getObject().getEmail();
+
+        log.info("Received ACK for incident: id={} from user={}", incidentId, userName);
+        final List<Alert> alerts = client.getAlerts(incidentId);
+        if (alerts != null && !alerts.isEmpty()) {
+            final Alert firstAlert = alerts.get(0);
+            final int alertId = alertIdFromAlertKey(firstAlert.getAlertKey());
+            if(!config.isDryRun()) {
+                alertStore.ackAlert(alertId, userName);
+                eventLog.log(PAGE_ACKNOWLEDGED, alertId, userName);
+                log.info("Acknowledged alert #{}", alertId);
+            } else {
+                log.info("Running in Dry-Run mode. No changes applied");
+            }
+        } else {
+            log.error("Couldn't obtain PagerDuty Alerts for Incident {}", incidentId);
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/RedisAlertStore.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/RedisAlertStore.java
@@ -1,0 +1,29 @@
+package org.zalando.zmon.notifications.pagerduty.webhook;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+public class RedisAlertStore implements AlertStore {
+    @VisibleForTesting
+    static final String ZMON_ALERT_ACKS = "zmon:alert-acks";
+
+    private final Logger log = LoggerFactory.getLogger(RedisAlertStore.class);
+
+    private final JedisPool pool;
+
+    public RedisAlertStore(final JedisPool pool) {
+        this.pool = pool;
+    }
+
+    @Override
+    public void ackAlert(int alertId, String userName) {
+        try(final Jedis jedis = pool.getResource()) {
+            jedis.sadd(ZMON_ALERT_ACKS, Integer.toString(alertId));
+        } catch(Exception ex) {
+            log.error("failed to ACK alert {} from user {}", alertId, userName, ex);
+        }
+    }
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/Acknowledger.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/Acknowledger.java
@@ -1,0 +1,27 @@
+package org.zalando.zmon.notifications.pagerduty.webhook.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Date;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Acknowledger {
+    private Date at;
+    private User object;
+
+    public Date getAt() {
+        return at;
+    }
+
+    public void setAt(Date at) {
+        this.at = at;
+    }
+
+    public User getObject() {
+        return object;
+    }
+
+    public void setObject(User object) {
+        this.object = object;
+    }
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/Callback.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/Callback.java
@@ -1,0 +1,17 @@
+package org.zalando.zmon.notifications.pagerduty.webhook.domain;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public class Callback {
+    private List<Message> messages = ImmutableList.of();
+
+    public List<Message> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(List<Message> messages) {
+        this.messages = messages;
+    }
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/Data.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/Data.java
@@ -1,0 +1,16 @@
+package org.zalando.zmon.notifications.pagerduty.webhook.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Data {
+    private Incident incident;
+
+    public Incident getIncident() {
+        return incident;
+    }
+
+    public void setIncident(Incident incident) {
+        this.incident = incident;
+    }
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/Incident.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/Incident.java
@@ -1,0 +1,55 @@
+package org.zalando.zmon.notifications.pagerduty.webhook.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Date;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Incident {
+    private String id;
+    private int incidentNumber;
+    private Date createdOn;
+    private IncidentStatus status;
+    private List<Acknowledger> acknowledgers;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public int getIncidentNumber() {
+        return incidentNumber;
+    }
+
+    public void setIncidentNumber(int incidentNumber) {
+        this.incidentNumber = incidentNumber;
+    }
+
+    public Date getCreatedOn() {
+        return createdOn;
+    }
+
+    public void setCreatedOn(Date createdOn) {
+        this.createdOn = createdOn;
+    }
+
+    public IncidentStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(IncidentStatus status) {
+        this.status = status;
+    }
+
+    public List<Acknowledger> getAcknowledgers() {
+        return acknowledgers;
+    }
+
+    public void setAcknowledgers(List<Acknowledger> acknowledgers) {
+        this.acknowledgers = acknowledgers;
+    }
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/IncidentStatus.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/IncidentStatus.java
@@ -1,0 +1,12 @@
+package org.zalando.zmon.notifications.pagerduty.webhook.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum IncidentStatus {
+    @JsonProperty("triggered")
+    TRIGGERED,
+    @JsonProperty("acknowledged")
+    ACKNOWLEDGED,
+    @JsonProperty("resolved")
+    RESOLVED
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/Message.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/Message.java
@@ -1,0 +1,45 @@
+package org.zalando.zmon.notifications.pagerduty.webhook.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Date;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Message {
+    private MessageType type;
+    private Data data;
+    private String id;
+    private Date createdOn;
+
+    public MessageType getType() {
+        return type;
+    }
+
+    public void setType(MessageType type) {
+        this.type = type;
+    }
+
+    public Data getData() {
+        return data;
+    }
+
+    public void setData(Data data) {
+        this.data = data;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Date getCreatedOn() {
+        return createdOn;
+    }
+
+    public void setCreatedOn(Date createdOn) {
+        this.createdOn = createdOn;
+    }
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/MessageType.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/MessageType.java
@@ -1,0 +1,21 @@
+package org.zalando.zmon.notifications.pagerduty.webhook.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+// https://v2.developer.pagerduty.com/docs/webhooks-overview#webhook-types
+public enum MessageType {
+    @JsonProperty("incident.trigger")
+    TRIGGER,
+    @JsonProperty("incident.acknowledge")
+    ACKNOWLEDGE,
+    @JsonProperty("incident.unacknowledge")
+    UNACKNOWLEDGE,
+    @JsonProperty("incident.resolve")
+    RESOLVE,
+    @JsonProperty("incident.assign")
+    ASSIGN,
+    @JsonProperty("incident.escalate")
+    ESCALATE,
+    @JsonProperty("incident.delegate")
+    DELEGATE
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/User.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/User.java
@@ -1,0 +1,52 @@
+package org.zalando.zmon.notifications.pagerduty.webhook.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class User {
+    private String id;
+    private String name;
+    private String email;
+    private String htmlUrl;
+    private UserType type;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getHtmlUrl() {
+        return htmlUrl;
+    }
+
+    public void setHtmlUrl(String htmlUrl) {
+        this.htmlUrl = htmlUrl;
+    }
+
+    public UserType getType() {
+        return type;
+    }
+
+    public void setType(UserType type) {
+        this.type = type;
+    }
+}

--- a/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/UserType.java
+++ b/src/main/java/org/zalando/zmon/notifications/pagerduty/webhook/domain/UserType.java
@@ -1,0 +1,8 @@
+package org.zalando.zmon.notifications.pagerduty.webhook.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum UserType {
+    @JsonProperty("user")
+    USER
+}

--- a/src/test/java/org/zalando/zmon/notifications/pagerduty/client/ClientTestUtils.java
+++ b/src/test/java/org/zalando/zmon/notifications/pagerduty/client/ClientTestUtils.java
@@ -1,0 +1,12 @@
+package org.zalando.zmon.notifications.pagerduty.client;
+
+public final class ClientTestUtils {
+    private ClientTestUtils() {}
+
+    public static Alert mockAlert(final String key) {
+        final Alert alert = new Alert();
+        alert.setAlertKey(key);
+        return alert;
+    }
+
+}

--- a/src/test/java/org/zalando/zmon/notifications/pagerduty/client/DefaultClientTest.java
+++ b/src/test/java/org/zalando/zmon/notifications/pagerduty/client/DefaultClientTest.java
@@ -1,0 +1,51 @@
+package org.zalando.zmon.notifications.pagerduty.client;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestOperations;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.zalando.zmon.notifications.pagerduty.client.ClientTestUtils.mockAlert;
+
+public class DefaultClientTest {
+    @Test
+    public void testGettingAlerts() throws Exception {
+        final RestOperations restOperationsMock = mock(RestOperations.class);
+        when(restOperationsMock.getForObject(anyString(), Mockito.eq(AlertsResponse.class)))
+                .thenReturn(mockAlertsResponse("alert1", "alert2"));
+
+        final PagerDutyClient client = new DefaultClient(restOperationsMock);
+        final List<Alert> alerts = client.getAlerts("foo");
+
+        assertThat(alerts, hasSize(2));
+    }
+
+    @Test(expected = HttpServerErrorException.class)
+    public void testGettingAlertsFailures() throws Exception {
+        final RestOperations restOperationsMock = mock(RestOperations.class);
+        when(restOperationsMock.getForObject(anyString(), Mockito.eq(AlertsResponse.class)))
+                .thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        final PagerDutyClient client = new DefaultClient(restOperationsMock);
+        client.getAlerts("bar");
+    }
+
+    private AlertsResponse mockAlertsResponse(String ... keys) {
+        final AlertsResponse response = new AlertsResponse();
+        final ImmutableList.Builder<Alert> builder = ImmutableList.builder();
+        for (final String key : keys) {
+            builder.add(mockAlert(key));
+        }
+        response.setAlerts(builder.build());
+        return response;
+    }
+}

--- a/src/test/java/org/zalando/zmon/notifications/pagerduty/client/PagerDutyClientInterceptorTest.java
+++ b/src/test/java/org/zalando/zmon/notifications/pagerduty/client/PagerDutyClientInterceptorTest.java
@@ -1,0 +1,34 @@
+package org.zalando.zmon.notifications.pagerduty.client;
+
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasKey;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class PagerDutyClientInterceptorTest {
+
+    private final ClientHttpRequestInterceptor interceptor = new PagerDutyClientInterceptor("test-psk");
+
+    @Test
+    public void testInterceptor() throws Exception {
+        final HttpRequest request = new MockClientHttpRequest();
+        final ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+        interceptor.intercept(request, null, execution);
+        verify(execution).execute(eq(request), any());
+        assertThat(request.getHeaders(), hasKey(HttpHeaders.AUTHORIZATION));
+        final List<String> authHeaderValues = request.getHeaders().get(HttpHeaders.AUTHORIZATION);
+        assertThat(authHeaderValues, hasItem("Token token=test-psk"));
+    }
+}

--- a/src/test/java/org/zalando/zmon/notifications/pagerduty/webhook/IntegrationHelperTest.java
+++ b/src/test/java/org/zalando/zmon/notifications/pagerduty/webhook/IntegrationHelperTest.java
@@ -1,0 +1,48 @@
+package org.zalando.zmon.notifications.pagerduty.webhook;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Parameterized.class)
+public class IntegrationHelperTest {
+    @Parameters(name = "alertKey={0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                {"ZMON-12345", 12345, null},
+                {"ZMON-FOO", 0, NumberFormatException.class },
+                {"BAR", 0, IllegalArgumentException.class },
+                {"12345", 0, IllegalArgumentException.class },
+                {"", 0, IllegalArgumentException.class },
+                {null, 0, IllegalArgumentException.class },
+        });
+    }
+
+    private String given;
+    private int want;
+    private Class wantExc;
+
+    public IntegrationHelperTest(String alertKey, int alertId, Class exceptionClass) {
+        this.given = alertKey;
+        this.want = alertId;
+        this.wantExc = exceptionClass;
+    }
+
+    @Test
+    public void test() {
+        try {
+            final int got = IntegrationHelper.alertIdFromAlertKey(given);
+            assertEquals(got, want);
+        } catch (Exception ex) {
+            assertThat(ex, Matchers.instanceOf(wantExc));
+        }
+    }
+}

--- a/src/test/java/org/zalando/zmon/notifications/pagerduty/webhook/PagerDutyWebHookControllerTest.java
+++ b/src/test/java/org/zalando/zmon/notifications/pagerduty/webhook/PagerDutyWebHookControllerTest.java
@@ -31,8 +31,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.zalando.zmon.notifications.ZMonEventType.PAGE_ACKNOWLEDGED;
 import static org.zalando.zmon.notifications.pagerduty.client.ClientTestUtils.mockAlert;
 
-//@RunWith(SpringRunner.class)
-//@WebMvcTest(PagerDutyWebHookController.class)
 @RunWith(MockitoJUnitRunner.class)
 public class PagerDutyWebHookControllerTest {
     @Mock

--- a/src/test/java/org/zalando/zmon/notifications/pagerduty/webhook/PagerDutyWebHookControllerTest.java
+++ b/src/test/java/org/zalando/zmon/notifications/pagerduty/webhook/PagerDutyWebHookControllerTest.java
@@ -11,7 +11,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.servlet.View;
 import org.zalando.zmon.notifications.HttpEventLogger;
 import org.zalando.zmon.notifications.config.NotificationServiceConfig;
 import org.zalando.zmon.notifications.oauth.TokenInfoService;
@@ -27,14 +26,13 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.zalando.zmon.notifications.ZMonEventType.PAGE_ACKNOWLEDGED;
 import static org.zalando.zmon.notifications.pagerduty.client.ClientTestUtils.mockAlert;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PagerDutyWebHookControllerTest {
-    @Mock
-    private View mockView;
     @Mock
     private TokenInfoService tokenInfoService;
     @Mock
@@ -52,7 +50,7 @@ public class PagerDutyWebHookControllerTest {
     public void setUp() {
         final Object webHookController = new PagerDutyWebHookController(pagerDutyClient, tokenInfoService,
                 config, httpEventLogger, alertStore);
-        mockMvc = MockMvcBuilders.standaloneSetup(webHookController).setSingleView(mockView).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(webHookController).alwaysDo(print()).build();
     }
 
     @Test

--- a/src/test/java/org/zalando/zmon/notifications/pagerduty/webhook/PagerDutyWebHookControllerTest.java
+++ b/src/test/java/org/zalando/zmon/notifications/pagerduty/webhook/PagerDutyWebHookControllerTest.java
@@ -1,0 +1,135 @@
+package org.zalando.zmon.notifications.pagerduty.webhook;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Resources;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.View;
+import org.zalando.zmon.notifications.HttpEventLogger;
+import org.zalando.zmon.notifications.config.NotificationServiceConfig;
+import org.zalando.zmon.notifications.oauth.TokenInfoService;
+import org.zalando.zmon.notifications.pagerduty.client.PagerDutyClient;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Optional;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.zalando.zmon.notifications.ZMonEventType.PAGE_ACKNOWLEDGED;
+import static org.zalando.zmon.notifications.pagerduty.client.ClientTestUtils.mockAlert;
+
+//@RunWith(SpringRunner.class)
+//@WebMvcTest(PagerDutyWebHookController.class)
+@RunWith(MockitoJUnitRunner.class)
+public class PagerDutyWebHookControllerTest {
+    @Mock
+    private View mockView;
+    @Mock
+    private TokenInfoService tokenInfoService;
+    @Mock
+    private PagerDutyClient pagerDutyClient;
+    @Mock
+    private AlertStore alertStore;
+    @Mock
+    private NotificationServiceConfig config;
+    @Mock
+    private HttpEventLogger httpEventLogger;
+
+    private MockMvc mockMvc;
+
+    @Before
+    public void setUp() {
+        final Object webHookController = new PagerDutyWebHookController(pagerDutyClient, tokenInfoService,
+                config, httpEventLogger, alertStore);
+        mockMvc = MockMvcBuilders.standaloneSetup(webHookController).setSingleView(mockView).build();
+    }
+
+    @Test
+    public void testAcknowledge() throws Exception {
+        when(tokenInfoService.lookupUid(anyString())).thenReturn(Optional.of("test"));
+        when(pagerDutyClient.getAlerts(anyString())).thenReturn(ImmutableList.of(mockAlert("ZMON-12345")));
+        mockMvc.perform(post("/api/v1/pagerduty/webhook")
+                .param("psk", "test-psk")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(testPayload("/pagerduty_webhook.json")))
+                .andExpect(status().isOk());
+        verify(alertStore).ackAlert(eq(12345), anyString());
+        verify(httpEventLogger).log(eq(PAGE_ACKNOWLEDGED), eq(12345), anyString());
+    }
+
+    @Test
+    public void testMissingAuth() throws Exception {
+        when(tokenInfoService.lookupUid(anyString())).thenReturn(Optional.empty());
+        mockMvc.perform(post("/api/v1/pagerduty/webhook")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(testPayload("/pagerduty_webhook.json")))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void testNoAlertsFromPagerDuty() throws Exception {
+        when(tokenInfoService.lookupUid(anyString())).thenReturn(Optional.of("test"));
+        when(pagerDutyClient.getAlerts(anyString())).thenReturn(ImmutableList.of());
+        mockMvc.perform(post("/api/v1/pagerduty/webhook")
+                .param("psk", "test-psk")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(testPayload("/pagerduty_webhook.json")))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    public void testMissingAcknowledgers() throws Exception {
+        when(tokenInfoService.lookupUid(anyString())).thenReturn(Optional.of("test"));
+        mockMvc.perform(post("/api/v1/pagerduty/webhook")
+                .param("psk", "test-psk")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(testPayload("/pagerduty_webhook_no_acknowledgers.json")))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    public void testDryRun() throws Exception {
+        when(config.isDryRun()).thenReturn(Boolean.TRUE);
+        when(tokenInfoService.lookupUid(anyString())).thenReturn(Optional.of("test"));
+        when(pagerDutyClient.getAlerts(anyString())).thenReturn(ImmutableList.of(mockAlert("ZMON-12345")));
+        mockMvc.perform(post("/api/v1/pagerduty/webhook")
+                .param("psk", "test-psk")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(testPayload("/pagerduty_webhook.json")))
+                .andExpect(status().isOk());
+        verify(alertStore, never()).ackAlert(anyInt(), anyString());
+        verify(httpEventLogger, never()).log(any(), anyInt(), anyString());
+    }
+
+    @Test
+    public void testUnsupportedMessageTypes() throws Exception {
+        when(tokenInfoService.lookupUid(anyString())).thenReturn(Optional.of("test"));
+        mockMvc.perform(post("/api/v1/pagerduty/webhook")
+                .param("psk", "test-psk")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(testPayload("/pagerduty_webhook_unsupported_msg_type.json")))
+                .andExpect(status().isOk());
+        verify(pagerDutyClient, never()).getAlerts(anyString());
+        verify(alertStore, never()).ackAlert(anyInt(), anyString());
+        verify(httpEventLogger, never()).log(any(), anyInt(), anyString());
+
+    }
+
+    private String testPayload(final String name) throws IOException {
+        final URL url = this.getClass().getResource(name);
+        return Resources.toString(url, Charsets.UTF_8);
+    }
+}

--- a/src/test/java/org/zalando/zmon/notifications/pagerduty/webhook/RedisAlertStoreTest.java
+++ b/src/test/java/org/zalando/zmon/notifications/pagerduty/webhook/RedisAlertStoreTest.java
@@ -1,0 +1,42 @@
+package org.zalando.zmon.notifications.pagerduty.webhook;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.zalando.zmon.notifications.pagerduty.webhook.RedisAlertStore.ZMON_ALERT_ACKS;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RedisAlertStoreTest {
+    @Mock
+    private Jedis jedis;
+
+    @Mock
+    private JedisPool jedisPool;
+
+    @InjectMocks
+    private RedisAlertStore redisAlertStore;
+
+    @Test
+    public void testAck() throws Exception {
+        when(jedisPool.getResource()).thenReturn(jedis);
+        when(jedis.sadd(anyString(), anyString())).thenReturn(Long.MAX_VALUE);
+        redisAlertStore.ackAlert(12345, "foo");
+        verify(jedis).sadd(ZMON_ALERT_ACKS, "12345");
+    }
+
+    @Test
+    public void testRedisFailure() throws Exception {
+        when(jedisPool.getResource()).thenReturn(jedis);
+        when(jedis.sadd(anyString(), anyString())).thenThrow(new RuntimeException("shit has hit the fan"));
+        redisAlertStore.ackAlert(12345, "foo");
+        verify(jedis).sadd(ZMON_ALERT_ACKS, "12345");
+    }
+}

--- a/src/test/resources/pagerduty_webhook.json
+++ b/src/test/resources/pagerduty_webhook.json
@@ -1,0 +1,85 @@
+{
+  "messages": [
+    {
+      "type": "incident.acknowledge",
+      "data": {
+        "incident": {
+          "id": "INC1234",
+          "incident_number": 28,
+          "created_on": "2017-05-04T14:18:31Z",
+          "status": "acknowledged",
+          "pending_actions": [
+            {
+              "type": "unacknowledge",
+              "at": "2017-05-04T14:49:48Z"
+            },
+            {
+              "type": "resolve",
+              "at": "2017-05-04T18:18:31Z"
+            }
+          ],
+          "html_url": "https://example.pagerduty.com/incidents/INC1234",
+          "incident_key": "db4254b34538426bad066bb12527bc1e",
+          "service": {
+            "id": "SVC1234",
+            "name": "ZMON Notifications",
+            "html_url": "https://example.pagerduty.com/services/SVC1234",
+            "deleted_at": null,
+            "description": "Test ZMON notifications"
+          },
+          "escalation_policy": {
+            "id": "ESC1234",
+            "name": "ZMON test",
+            "deleted_at": null
+          },
+          "assigned_to_user": {
+            "id": "USR1234",
+            "name": "John Doe",
+            "email": "john.doe@domain.com",
+            "html_url": "https://example.pagerduty.com/users/USR1234"
+          },
+          "trigger_summary_data": {
+            "subject": "webhook"
+          },
+          "trigger_details_html_url": "https://example.pagerduty.com/incidents/INC1234/log_entries/XXXYYYZZZ",
+          "trigger_type": "web_trigger",
+          "last_status_change_on": "2017-05-04T14:19:48Z",
+          "last_status_change_by": {
+            "id": "USR1234",
+            "name": "John Doe",
+            "email": "john.doe@domain.com",
+            "html_url": "https://example.pagerduty.com/users/USR1234"
+          },
+          "number_of_escalations": null,
+          "assigned_to": [
+            {
+              "at": "2017-05-04T14:19:48Z",
+              "object": {
+                "id": "USR1234",
+                "name": "John Doe",
+                "email": "john.doe@domain.com",
+                "html_url": "https://zalando.pagerduty.com/users/USR1234",
+                "type": "user"
+              }
+            }
+          ],
+          "acknowledgers": [
+            {
+              "at": "2017-05-04T14:19:48Z",
+              "object": {
+                "id": "USR1234",
+                "name": "John Doe",
+                "email": "john.doe@domain.com",
+                "html_url": "https://example.pagerduty.com/users/USR1234",
+                "type": "user"
+              }
+            }
+          ],
+          "urgency": "low"
+        }
+      },
+      "id": "ed18249c-7e6f-4f4e-9ea1-1a11548fef75",
+      "created_on": "2017-05-04T14:19:48Z"
+    }
+  ]
+}

--- a/src/test/resources/pagerduty_webhook_no_acknowledgers.json
+++ b/src/test/resources/pagerduty_webhook_no_acknowledgers.json
@@ -1,0 +1,74 @@
+{
+  "messages": [
+    {
+      "type": "incident.acknowledge",
+      "data": {
+        "incident": {
+          "id": "INC1234",
+          "incident_number": 28,
+          "created_on": "2017-05-04T14:18:31Z",
+          "status": "acknowledged",
+          "pending_actions": [
+            {
+              "type": "unacknowledge",
+              "at": "2017-05-04T14:49:48Z"
+            },
+            {
+              "type": "resolve",
+              "at": "2017-05-04T18:18:31Z"
+            }
+          ],
+          "html_url": "https://example.pagerduty.com/incidents/INC1234",
+          "incident_key": "db4254b34538426bad066bb12527bc1e",
+          "service": {
+            "id": "SVC1234",
+            "name": "ZMON Notifications",
+            "html_url": "https://example.pagerduty.com/services/SVC1234",
+            "deleted_at": null,
+            "description": "Test ZMON notifications"
+          },
+          "escalation_policy": {
+            "id": "ESC1234",
+            "name": "ZMON test",
+            "deleted_at": null
+          },
+          "assigned_to_user": {
+            "id": "USR1234",
+            "name": "John Doe",
+            "email": "john.doe@domain.com",
+            "html_url": "https://example.pagerduty.com/users/USR1234"
+          },
+          "trigger_summary_data": {
+            "subject": "webhook"
+          },
+          "trigger_details_html_url": "https://example.pagerduty.com/incidents/INC1234/log_entries/XXXYYYZZZ",
+          "trigger_type": "web_trigger",
+          "last_status_change_on": "2017-05-04T14:19:48Z",
+          "last_status_change_by": {
+            "id": "USR1234",
+            "name": "John Doe",
+            "email": "john.doe@domain.com",
+            "html_url": "https://example.pagerduty.com/users/USR1234"
+          },
+          "number_of_escalations": null,
+          "assigned_to": [
+            {
+              "at": "2017-05-04T14:19:48Z",
+              "object": {
+                "id": "USR1234",
+                "name": "John Doe",
+                "email": "john.doe@domain.com",
+                "html_url": "https://zalando.pagerduty.com/users/USR1234",
+                "type": "user"
+              }
+            }
+          ],
+          "acknowledgers": [],
+          "urgency": "low"
+        }
+      },
+      "id": "ed18249c-7e6f-4f4e-9ea1-1a11548fef75",
+      "created_on": "2017-05-04T14:19:48Z"
+    }
+  ]
+}

--- a/src/test/resources/pagerduty_webhook_unsupported_msg_type.json
+++ b/src/test/resources/pagerduty_webhook_unsupported_msg_type.json
@@ -1,0 +1,9 @@
+{
+  "messages": [
+    {
+      "type": "incident.trigger",
+      "id": "ed18249c-7e6f-4f4e-9ea1-1a11548fef75",
+      "created_on": "2017-05-04T14:19:48Z"
+    }
+  ]
+}


### PR DESCRIPTION
This is the bare minimum to change alert state on ZMON whenever a user ACKs a PagerDuty incident.

The controller still needs to pick this up and reflect it in the UI.

There's also the cleanup done by the LUA script in the data-service.